### PR TITLE
build: Add GitHub bot to check license headers

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file configures a GitHub Bot called "License Header Lint GCF": https://github.com/apps/license-header-lint-gcf
+# The bot runs a GitHub check called "header-check" (inside pull-requests) that warns us about invalid/missing license headers.
+# The schema for this configutation file is documented at https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint.
+
+allowedCopyrightHolders:
+  - 'Google LLC'
+
+allowedLicenses:
+  - 'Apache-2.0'
+
+# If you want to ignore certain files/folders, use ignoreFiles.
+# ignoreFiles:
+#  - '**/requirements.txt'
+
+# If you want to ignore checking the license year, use ignoreLicenseYear.
+# ignoreLicenseYear: true # Useful when migrating in code licensed at previous years.
+
+sourceFileExtensions:
+  - 'Dockerfile'
+  - 'tf'
+  - 'yaml'
+  - 'yml'

--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -31,6 +31,11 @@ allowedLicenses:
 
 sourceFileExtensions:
   - 'Dockerfile'
+  - 'go'
+  - 'html'
+  - 'js'
+  - 'scss'
   - 'tf'
+  - 'ts'
   - 'yaml'
   - 'yml'


### PR DESCRIPTION
* This fixes #6.
* [Docs about configuring the bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint#header-checker-lint).
* It's unreasonable to expect that we cover all possible file extensions for this repo, so (for now), let's just cover comment-supporting file extensions that appear at least ~3 or more times.
* I used [a command](https://stackoverflow.com/a/55317141) to check the frequency of each file extension. Warning: The command misses files without dots (e.g., Dockerfile, Makefile). See output below:

```
  34 tf ✅ 
  29 ts ✅ 
  18 yaml ✅ 
  14 sample
  14 go ✅ 
  13 md
  11 html ✅ 
   8 json
   6 scss ✅ 
   3 yml ✅ 
   3 sh ✅ 
   2 sum
   2 png
   2 mod
   1 toml
   1 rev
   1 pack
   1 js ✅ 
   1 idx
   1 ico
   1 gitkeep
   1 gitignore
   1 editorconfig
   1 dockerignore
   1 conf
```

* ✅  = included in header-checker-lint.yml
* I've also included `Dockerfile` which isn't capture by the above command/output because it doesn't contain a dot.
* **How to review:** Notice the `header-check` GitHub check running against this pull-request.
* If you want to see a failing example, see [this kubernetes-engine-samples pull-request](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/964).
